### PR TITLE
[core] Add cancellation to [Enqueue|Dequeue]Async

### DIFF
--- a/src/ReusableTasks.Tests/AsyncBoundedQueueTests.cs
+++ b/src/ReusableTasks.Tests/AsyncBoundedQueueTests.cs
@@ -114,7 +114,7 @@ namespace ReusableTasks.Tests
         }
 
         [Test]
-        public async Task DequeueFirst ()
+        public async Task DequeueFirst_Bounded ()
         {
             var queue = new AsyncProducerConsumerQueue<int> (2);
 
@@ -123,6 +123,18 @@ namespace ReusableTasks.Tests
 
             await queue.EnqueueAsync (5);
             Assert.AreEqual (5, await task.WithTimeout ("#2"));
+        }
+
+        [Test]
+        public async Task DequeueFirst_Unbounded()
+        {
+            var queue = new AsyncProducerConsumerQueue<int>(0);
+
+            var task = queue.DequeueAsync();
+            Assert.IsFalse(task.IsCompleted, "#1");
+
+            await queue.EnqueueAsync(5);
+            Assert.AreEqual(5, await task.WithTimeout("#2"));
         }
 
         [Test]

--- a/src/ReusableTasks.Tests/ReusableTaskExtensions.cs
+++ b/src/ReusableTasks.Tests/ReusableTaskExtensions.cs
@@ -14,6 +14,7 @@ namespace ReusableTasks.Tests
             var t = task.AsTask ();
             if (await Task.WhenAny (Task.Delay (Timeout), t) != t)
                 Assert.Fail ("The task timed out. {0}", message);
+            await t;
         }
 
         public static async ReusableTask<T> WithTimeout<T> (this ReusableTask<T> task, string message)

--- a/src/ReusableTasks/ReusableTasks/AsyncBoundedQueue.cs
+++ b/src/ReusableTasks/ReusableTasks/AsyncBoundedQueue.cs
@@ -101,7 +101,7 @@ namespace ReusableTasks
                     if (Queue.Count == 0 && IsAddingCompleted)
                         throw new InvalidOperationException ("This queue has been marked as complete, so no further items can be added.");
 
-                    if (Queue.Count > 0 || !IsBounded) {
+                    if (Queue.Count > 0) {
                         token.ThrowIfCancellationRequested();
                         var result = Queue.Dequeue ();
                         if (Queue.Count == Capacity - 1)

--- a/src/ReusableTasks/ReusableTasks/AsyncBoundedQueue.cs
+++ b/src/ReusableTasks/ReusableTasks/AsyncBoundedQueue.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace ReusableTasks
 {
@@ -10,6 +11,17 @@ namespace ReusableTasks
     /// <typeparam name="T"></typeparam>
     public class AsyncProducerConsumerQueue<T>
     {
+        Action cancelDequeuedCallback;
+        Action cancelEnqueuedCallback;
+
+        Action CancelDequeuedCallback {
+            get => cancelDequeuedCallback ?? (cancelDequeuedCallback = CancelDequeued);
+        }
+
+        Action CancelEnqueuedCallback {
+            get => cancelEnqueuedCallback ?? (cancelEnqueuedCallback = CancelEnqueued);
+        }
+
         /// <summary>
         /// The maximum number of work items which can be queued. A value of zero means there is
         /// no limit.
@@ -49,6 +61,10 @@ namespace ReusableTasks
             Queue = new Queue<T> ();
         }
 
+        void CancelDequeued() => Dequeued.TrySetCanceled();
+
+        void CancelEnqueued() => Enqueued.TrySetCanceled();
+
         /// <summary>
         /// Sets <see cref="IsAddingCompleted"/> to true and interrupts any pending <see cref="DequeueAsync"/>
         /// calls if the collection is already empty. Future calls to <see cref="EnqueueAsync(T)"/> will throw
@@ -68,7 +84,17 @@ namespace ReusableTasks
         /// will be added.
         /// /// </summary>
         /// <returns></returns>
-        public async ReusableTask<T> DequeueAsync ()
+        public ReusableTask<T> DequeueAsync()
+            => DequeueAsync(CancellationToken.None);
+
+        /// <summary>
+        /// If an item has already been enqueued, then it will be dequeued and returned synchronously. Otherwise an
+        /// item must be enqueued before this will return.
+        /// will be added.
+        /// /// </summary>
+        /// <param name="token">The token used to cancel the pending dequeue.</param>
+        /// <returns></returns>
+        public async ReusableTask<T> DequeueAsync (CancellationToken token)
         {
             while (true) {
                 lock (Queue) {
@@ -76,13 +102,16 @@ namespace ReusableTasks
                         throw new InvalidOperationException ("This queue has been marked as complete, so no further items can be added.");
 
                     if (Queue.Count > 0 || !IsBounded) {
+                        token.ThrowIfCancellationRequested();
                         var result = Queue.Dequeue ();
                         if (Queue.Count == Capacity - 1)
                             Dequeued.TrySetResult (true);
                         return result;
                     }
                 }
-                await Enqueued.Task;
+
+                using (var registration = token == CancellationToken.None ? default : token.Register(CancelEnqueuedCallback))
+                    await Enqueued.Task.ConfigureAwait (false);
             }
         }
 
@@ -93,7 +122,18 @@ namespace ReusableTasks
         /// /// </summary>
         /// <param name="value">The item to enqueue</param>
         /// <returns></returns>
-        public async ReusableTask EnqueueAsync (T value)
+        public ReusableTask EnqueueAsync(T value)
+            => EnqueueAsync(value, CancellationToken.None);
+
+        /// <summary>
+        /// The new item will be enqueued synchronously if the number of items already
+        /// enqueued is less than the capacity. Otherwise an item must be dequeued before the new item
+        /// will be added.
+        /// /// </summary>
+        /// <param name="value">The item to enqueue</param>
+        /// <param name="token">The token used to cancel the pending enqueue.</param>
+        /// <returns></returns>
+        public async ReusableTask EnqueueAsync(T value, CancellationToken token)
         {
             if (IsAddingCompleted)
                 throw new InvalidOperationException ("This queue has been marked as complete, so no further items can be added.");
@@ -101,13 +141,15 @@ namespace ReusableTasks
             while (true) {
                 lock (Queue) {
                     if (Queue.Count < Capacity || !IsBounded) {
+                        token.ThrowIfCancellationRequested();
                         Queue.Enqueue (value);
                         if (Queue.Count == 1)
                             Enqueued.TrySetResult (true);
                         return;
                     }
                 }
-                await Dequeued.Task;
+                using (var registration = token == CancellationToken.None ? default : token.Register(CancelDequeuedCallback))
+                    await Dequeued.Task.ConfigureAwait(false);
             }
         }
     }

--- a/src/ReusableTasks/ReusableTasks/AsyncBoundedQueue.cs
+++ b/src/ReusableTasks/ReusableTasks/AsyncBoundedQueue.cs
@@ -66,7 +66,7 @@ namespace ReusableTasks
         void CancelEnqueued() => Enqueued.TrySetCanceled();
 
         /// <summary>
-        /// Sets <see cref="IsAddingCompleted"/> to true and interrupts any pending <see cref="DequeueAsync"/>
+        /// Sets <see cref="IsAddingCompleted"/> to true and interrupts any pending <see cref="DequeueAsync()"/>
         /// calls if the collection is already empty. Future calls to <see cref="EnqueueAsync(T)"/> will throw
         /// an <see cref="InvalidOperationException"/>.
         /// </summary>


### PR DESCRIPTION
It may not be zero-allocation if you're using a real
CancellationToken, but it's still zero allocation in
other scenarios.

Glorious!